### PR TITLE
Add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ The only env variable is `VITE_HOME_CALENDAR_API_URL` — the base URL for the b
 
 This is a single-page React 19 app that renders a FullCalendar weekly view backed by a REST API.
 
-**Data flow:** `App.tsx` initializes `HomeCalendarApiClient` with the API URL from env, fetches events for the current week on mount using `date-utils.ts` helpers, and passes them to FullCalendar as the initial event set.
+**Data flow:** `App.tsx` initializes `HomeCalendarApiClient` with the API URL from env, fetches events for the current week on mount using `date-utils.ts` helpers, and passes them to FullCalendar as the initial event set. The home_calendar API is defined in `home_calendar_swagger.yaml`
 
 **API client** (`src/HomeCalendarApiClient.ts`): Typed REST client with methods for CRUD on events. Events support recurring series via `recurring_uuid` and an `applyToSeries` flag on delete.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm install          # Install dependencies
+npm run dev          # Start dev server at http://localhost:5173/
+npm run build        # TypeScript compile + Vite production build
+npm run lint         # ESLint check
+docker compose up    # Run production build at http://localhost:8080/
+```
+
+There are no tests in this project.
+
+## Environment Setup
+
+Copy the sample env file before running locally:
+```bash
+cp .env.development.sample .env.development
+```
+
+The only env variable is `VITE_HOME_CALENDAR_API_URL` — the base URL for the backend API (defaults to `http://localhost:3000/api/v1` if unset).
+
+## Architecture
+
+This is a single-page React 19 app that renders a FullCalendar weekly view backed by a REST API.
+
+**Data flow:** `App.tsx` initializes `HomeCalendarApiClient` with the API URL from env, fetches events for the current week on mount using `date-utils.ts` helpers, and passes them to FullCalendar as the initial event set.
+
+**API client** (`src/HomeCalendarApiClient.ts`): Typed REST client with methods for CRUD on events. Events support recurring series via `recurring_uuid` and an `applyToSeries` flag on delete.
+
+**Calendar** (`src/App.tsx`): FullCalendar configured for `timeGridWeek` default view (dayGridMonth and timeGridDay also available), showing 08:00–23:00 UTC with no all-day slot.
+
+**Styling**: Tailwind CSS v4 via the Vite plugin — imported as a single `@import "tailwindcss"` in `index.css`.
+
+**Production deploy**: Multi-stage Docker build (Node 24 builder → Nginx alpine), served on port 8080.

--- a/home_calendar_swagger.yaml
+++ b/home_calendar_swagger.yaml
@@ -1,0 +1,260 @@
+---
+openapi: 3.0.1
+info:
+  title: Home Calendar API
+  version: 1.0.0
+  description: |
+    API for managing calendar events, including recurring series.
+servers:
+- url: "{protocol}://{host}:{port}"
+  variables:
+    protocol:
+      default: http
+    host:
+      default: localhost
+    port:
+      default: '3000'
+
+paths:
+  /api/v1/events:
+    get:
+      summary: List events in a date range
+      operationId: listEvents
+      parameters:
+        - in: query
+          name: start
+          required: true
+          schema:
+            type: string
+            format: date-time
+          description: Start of the date range (inclusive)
+        - in: query
+          name: end
+          required: true
+          schema:
+            type: string
+            format: date-time
+          description: End of the date range (inclusive)
+      responses:
+        '200':
+          description: A list of events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+        '400':
+          description: Missing or invalid parameters
+          content:
+            text/plain:
+              schema:
+                type: string
+    post:
+      summary: Create a new event (or series)
+      operationId: createEvent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventInput'
+      responses:
+        '201':
+          description: Event(s) created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+        '400':
+          description: Validation errors
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+
+  /api/v1/events/{id}:
+    get:
+      summary: Retrieve a single event
+      operationId: getEvent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Event ID
+      responses:
+        '200':
+          description: Event found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+        '404':
+          description: Event not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+    patch:
+      summary: Update an event (or series)
+      operationId: updateEvent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Event ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventInput'
+      responses:
+        '200':
+          description: Event(s) updated
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+        '400':
+          description: Validation errors
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '404':
+          description: Event not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+    delete:
+      summary: Delete an event (or series)
+      operationId: deleteEvent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: Event ID
+        - in: query
+          name: apply_to_series
+          required: false
+          schema:
+            type: boolean
+          description: |
+            If true, delete the entire series; otherwise delete only this occurrence.
+      responses:
+        '204':
+          description: Event(s) deleted
+        '404':
+          description: Event not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+
+components:
+  schemas:
+    Event:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        start:
+          type: string
+          format: date-time
+        end:
+          type: string
+          format: date-time
+        color:
+          type: string
+          enum:
+            - ""
+            - black
+            - green
+            - red
+            - midnightblue
+            - indigo
+            - darkorange
+            - sienna
+            - teal
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        recurring_uuid:
+          type: string
+          nullable: true
+      required:
+        - id
+        - start
+        - end
+    EventInput:
+      type: object
+      properties:
+        event:
+          type: object
+          properties:
+            title:
+              type: string
+            start:
+              type: string
+              format: date-time
+            end:
+              type: string
+              format: date-time
+            color:
+              type: string
+              enum:
+                - ""
+                - black
+                - green
+                - red
+                - midnightblue
+                - indigo
+                - darkorange
+                - sienna
+                - teal
+            recurring_times:
+              type: integer
+            apply_to_series:
+              type: string
+              nullable: true
+              enum:
+                - "0"
+                - "1"
+                - null
+            recurring_schedule:
+              type: string
+              nullable: true
+              enum:
+                - null
+                - daily
+                - weekly
+                - monthly
+                - every 2 weeks
+                - every other day
+          required:
+            - start
+            - end


### PR DESCRIPTION
This pull request introduces initial project documentation and a full OpenAPI specification for the Home Calendar API. The changes provide guidance for development and a complete API contract for frontend-backend integration, including support for recurring events and series operations.

**Documentation and Developer Guidance:**

* Added `CLAUDE.md` with setup instructions, project architecture overview, environment configuration, and development commands for working with the React calendar frontend.

**API Specification:**

* Added `home_calendar_swagger.yaml`, defining the Home Calendar REST API using OpenAPI 3.0.1. This includes:
  - Endpoints for listing, creating, retrieving, updating, and deleting calendar events.
  - Support for recurring event series, including parameters for handling series operations.
  - Detailed schema definitions for `Event` and `EventInput`, covering all event fields and recurrence options.