### PR TITLE
Cleanup For Home Calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Home Calendar</title>
   </head>
   <body>
-    <div id="root" class="h-screen mb-8"></div>
+    <div id="root" class="min-h-screen pb-8"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Home Calendar</title>
   </head>
   <body>
-    <div id="root" class="h-screen"></div>
+    <div id="root" class="h-screen mb-8"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Home Calendar</title>
   </head>
   <body>
-    <div id="root" class="min-h-screen pb-8"></div>
+    <div id="root" class="h-screen pb-8"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,7 +85,7 @@ function App() {
         allDaySlot={false}
         slotMinTime={"08:00:00"}
         slotMaxTime={"23:00:00"}
-        nowIndicator={true}
+        nowIndicator={false}
         events={events}
         datesSet={handleDatesSet}
         eventClick={handleEventClick}

--- a/src/EventModal.tsx
+++ b/src/EventModal.tsx
@@ -125,7 +125,7 @@ export default function EventModal(props: EventModalProps) {
               onChange={(e) => { setTitle(e.target.value); }}
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
               placeholder="Event title"
-              autoFocus
+              autoFocus={window.innerWidth > 768}
             />
           </div>
 

--- a/src/EventModal.tsx
+++ b/src/EventModal.tsx
@@ -125,7 +125,7 @@ export default function EventModal(props: EventModalProps) {
               onChange={(e) => { setTitle(e.target.value); }}
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
               placeholder="Event title"
-              autoFocus={window.innerWidth > 768}
+              autoFocus={typeof window !== 'undefined' && window.innerWidth > 768}
             />
           </div>
 


### PR DESCRIPTION
This pull request introduces a few minor UI adjustments to improve the user experience, particularly for responsiveness and calendar display. The changes are straightforward and focus on layout, event modal behavior, and calendar configuration.

UI and Layout improvements:
* Added a bottom margin (`mb-8`) to the `#root` div in `index.html` to improve page spacing.

Calendar configuration:
* Disabled the "now" indicator in the calendar by setting `nowIndicator` to `false` in `App.tsx`.

Event modal responsiveness:
* Changed the autofocus behavior of the event title input to only enable autofocus on screens wider than 768px, improving usability on mobile devices in `EventModal.tsx`.