### PR TITLE
Add Color List

### DIFF
--- a/src/EventModal.tsx
+++ b/src/EventModal.tsx
@@ -50,6 +50,17 @@ export default function EventModal(props: EventModalProps) {
   const [color, setColor] = useState(
     isCreate ? '#3b82f6' : props.clickInfo.event.backgroundColor
   );
+  const colorMap: Record<string, string> = {
+    "#3b82f6": "default blue",
+    "#000000": "black",
+    "#008000": "green",
+    "#ff0000": "red",
+    "#191970": "midnightblue",
+    "#4b0082": "indigo",
+    "#ff8c00": "darkorange",
+    "#a0522d": "sienna",
+    "#008080": "teal"
+  };
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -156,11 +167,22 @@ export default function EventModal(props: EventModalProps) {
             <div className="flex items-center gap-3">
               <input
                 type="color"
+                list="color-list"
                 value={color}
                 onChange={(e) => { setColor(e.target.value); }}
                 className="h-9 w-16 cursor-pointer rounded border border-gray-300 p-0.5"
               />
-              <span className="text-base text-gray-500">{color}</span>
+              <span className="text-base text-gray-500">{colorMap[color] ?? color}</span>
+              <datalist id="color-list">
+                <option value="#000000"></option>
+                <option value="#008000"></option>
+                <option value="#ff0000"></option>
+                <option value="#191970"></option>
+                <option value="#4b0082"></option>
+                <option value="#ff8c00"></option>
+                <option value="#a0522d"></option>
+                <option value="#008080"></option>
+              </datalist>
             </div>
           </div>
 

--- a/src/EventModal.tsx
+++ b/src/EventModal.tsx
@@ -40,9 +40,9 @@ const colorMap: Record<string, string> = {
   "#000000": "black",
   "#008000": "green",
   "#ff0000": "red",
-  "#191970": "midnightblue",
+  "#191970": "midnight blue",
   "#4b0082": "indigo",
-  "#ff8c00": "darkorange",
+  "#ff8c00": "dark orange",
   "#a0522d": "sienna",
   "#008080": "teal"
 };
@@ -173,9 +173,10 @@ export default function EventModal(props: EventModalProps) {
                 onChange={(e) => { setColor(e.target.value); }}
                 className="h-9 w-16 cursor-pointer rounded border border-gray-300 p-0.5"
               />
-              <span className="text-base text-gray-500">{colorMap[color] ?? color}</span>
+              <span className="text-base text-gray-500">{colorMap[color.toLowerCase()] ?? color}</span>
             </div>
             <datalist id="color-list">
+              <option value="#3b82f6"></option>
               <option value="#000000"></option>
               <option value="#008000"></option>
               <option value="#ff0000"></option>

--- a/src/EventModal.tsx
+++ b/src/EventModal.tsx
@@ -35,6 +35,18 @@ function toISO(local: string): string {
   return `${local}:00Z`;
 }
 
+const colorMap: Record<string, string> = {
+  "#3b82f6": "default blue",
+  "#000000": "black",
+  "#008000": "green",
+  "#ff0000": "red",
+  "#191970": "midnightblue",
+  "#4b0082": "indigo",
+  "#ff8c00": "darkorange",
+  "#a0522d": "sienna",
+  "#008080": "teal"
+};
+
 export default function EventModal(props: EventModalProps) {
   const isCreate = props.mode === 'create';
 
@@ -50,17 +62,6 @@ export default function EventModal(props: EventModalProps) {
   const [color, setColor] = useState(
     isCreate ? '#3b82f6' : props.clickInfo.event.backgroundColor
   );
-  const colorMap: Record<string, string> = {
-    "#3b82f6": "default blue",
-    "#000000": "black",
-    "#008000": "green",
-    "#ff0000": "red",
-    "#191970": "midnightblue",
-    "#4b0082": "indigo",
-    "#ff8c00": "darkorange",
-    "#a0522d": "sienna",
-    "#008080": "teal"
-  };
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/src/EventModal.tsx
+++ b/src/EventModal.tsx
@@ -174,17 +174,17 @@ export default function EventModal(props: EventModalProps) {
                 className="h-9 w-16 cursor-pointer rounded border border-gray-300 p-0.5"
               />
               <span className="text-base text-gray-500">{colorMap[color] ?? color}</span>
-              <datalist id="color-list">
-                <option value="#000000"></option>
-                <option value="#008000"></option>
-                <option value="#ff0000"></option>
-                <option value="#191970"></option>
-                <option value="#4b0082"></option>
-                <option value="#ff8c00"></option>
-                <option value="#a0522d"></option>
-                <option value="#008080"></option>
-              </datalist>
             </div>
+            <datalist id="color-list">
+              <option value="#000000"></option>
+              <option value="#008000"></option>
+              <option value="#ff0000"></option>
+              <option value="#191970"></option>
+              <option value="#4b0082"></option>
+              <option value="#ff8c00"></option>
+              <option value="#a0522d"></option>
+              <option value="#008080"></option>
+            </datalist>
           </div>
 
           {error !== null && <p className="text-base text-red-600">{error}</p>}


### PR DESCRIPTION
This pull request enhances the color selection experience in the `EventModal` component by providing user-friendly color names and a predefined color palette. The most important changes are:

**User Interface Improvements:**

* Added a `colorMap` object to map color hex codes to human-readable color names, improving clarity for users when selecting event colors.
* Updated the color input to display the mapped color name (or the hex code if not mapped) next to the color picker for better usability.
* Introduced a `<datalist>` with a curated set of color options, allowing users to choose from a predefined palette in the color picker.