### PR TITLE
Add Now Indicator to Calendar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,7 +85,8 @@ function App() {
         allDaySlot={false}
         slotMinTime={"08:00:00"}
         slotMaxTime={"23:00:00"}
-        nowIndicator={false}
+        nowIndicator={true}
+        now={new Date(new Date().getTime() - new Date().getTimezoneOffset() * 60000)}
         events={events}
         datesSet={handleDatesSet}
         eventClick={handleEventClick}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,7 +86,10 @@ function App() {
         slotMinTime={"08:00:00"}
         slotMaxTime={"23:00:00"}
         nowIndicator={true}
-        now={new Date(new Date().getTime() - new Date().getTimezoneOffset() * 60000)}
+        now={() => {
+          const d = new Date();
+          return new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+        }}
         events={events}
         datesSet={handleDatesSet}
         eventClick={handleEventClick}


### PR DESCRIPTION
This pull request makes a small but important change to the calendar component in `src/App.tsx`: it enables the "now" indicator and ensures the current time is displayed accurately according to the user's local timezone.

- Calendar improvements:
  * Enabled the `nowIndicator` to visually show the current time on the calendar.
  * Set the `now` prop to the user's local time, correcting for timezone offset to ensure accurate display of the current time.